### PR TITLE
Add Flask and Postgresql as test fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Forum website to share recipes and other cooking related things
 ### Prerequisites
 
 Python 3
+Postgresql 14
 
 ### Steps
 

--- a/app.py
+++ b/app.py
@@ -2,13 +2,17 @@ from flask import Flask, render_template
 import os
 import random
 
-app = Flask(__name__)
+def create_app():
+    app = Flask(__name__)
 
-@app.route("/")
-def home():
-    return render_template("/home.html", value = random.randrange(1024))
+    @app.route("/")
+    def home():
+        return render_template("/home.html", value = random.randrange(1024))
+
+    return app
 
 
 if __name__ == "__main__":
+    app = create_app()
     app.debug = os.getenv("DEBUG") == "true"
     app.run()

--- a/project/schema.sql
+++ b/project/schema.sql
@@ -1,0 +1,6 @@
+-- replace this with the actual database schema
+
+CREATE TABLE dummy (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,12 @@ MarkupSafe==2.1.1
 packaging==21.3
 pluggy==1.0.0
 psycopg2-binary==2.9.3
+psycopg[binary]==3.1.3
 py==1.11.0
 pyparsing==3.0.9
 pytest==7.1.3
 pytest-flask==1.2.0
+pytest-postgresql==4.1.1
 pytest-cov==4.0.0
 tomli==2.0.1
 Werkzeug==2.2.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from app import create_app
+from pytest_postgresql import factories
+
+@pytest.fixture
+def app():
+    return create_app()
+
+@pytest.fixture
+def db_session(postgresql):
+    cur = postgresql.cursor()
+    cur.execute(open("./project/schema.sql", "r").read())
+    postgresql.commit()
+    return postgresql

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -3,6 +3,27 @@
 
 import project
 
-def test_i_just_always_pass():
-  assert True
+def test_home(client):
+    assert client.get("/").status_code == 200
+
+def test_1(db_session):
+    cur = db_session.cursor()
+    cur.execute("""
+        INSERT INTO dummy
+        VALUES (DEFAULT, 'Abcd1234')
+    """)
+    db_session.commit()
+
+    cur = db_session.cursor()
+    data = cur.execute("""
+        SELECT * FROM dummy
+    """).fetchone()
+    assert data[1] == 'Abcd1234'
+
+def test_2(db_session):
+    cur = db_session.cursor()
+    data = cur.execute("""
+        SELECT * FROM dummy
+    """).fetchone()
+    assert data is None
 


### PR DESCRIPTION
Close #9 

An unfortunate consequence of this change (see below for workarounds?) is that ***if you don't have access to some postgres, be it locally or (somehow) remotely, you can't run any tests locally***, which sounds like really bad news.

(tests always run when you open a PR on GitHub)

For more details on how to configure the postgresql fixture, see [here](https://github.com/ClearcodeHQ/pytest-postgresql#configuration).

The functions `test_1` and `test_2` is just showing that the two tests are isolated and that the fixture stuff is working.