### PR TITLE
Add recipe (and many other) schemas

### DIFF
--- a/project/schema.sql
+++ b/project/schema.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS accounts (
+  id SERIAL PRIMARY KEY
+
+  -- rest omitted: it's beyond the scope of this task
+);
+
+CREATE TABLE IF NOT EXISTS recipes (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  prep_time TIME,
+  cook_time TIME,
+  directions TEXT NOT NULL, -- assume it's all lumped as markdown text or sth
+  author INTEGER NOT NULL REFERENCES accounts (id)
+);
+
+CREATE TABLE IF NOT EXISTS ingredients (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  quantity TEXT NOT NULL,
+  recipe INTEGER NOT NULL REFERENCES recipes (id)
+);
+
+CREATE TABLE IF NOT EXISTS comments (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  author INTEGER NOT NULL REFERENCES accounts (id),
+  recipe INTEGER NOT NULL REFERENCES recipes (id)
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS recipe_tags (
+  recipe INTEGER NOT NULL REFERENCES recipes (id),
+  tag INTEGER NOT NULL REFERENCES tags (id),
+
+  PRIMARY KEY (recipe, tag)
+);


### PR DESCRIPTION
Close #31 
Close #45 
Close #57 
Close #55 

Some considerations:
* The definition of `accounts` is in #102. I can move that over to this PR as well
* The fields mostly come from the feature files, hopefully I didn't miss anything too important 🙏 
* Preparation and cook time have type [time](https://www.postgresql.org/docs/9.1/datatype-datetime.html), they can be `NULL` in case the author is not sure?
* Directions is assumed to be just a lump of text
* Things for Sprint 2 are completely ignored (looking right at you likes-and-favourites 👀) 
